### PR TITLE
add hello world test and fix config map ownership bug

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -45,3 +45,49 @@ jobs:
         cp examples/dist/metrics-operator.yaml /tmp/metrics-operator.yaml
         make build-config
         diff examples/dist/metrics-operator.yaml /tmp/metrics-operator.yaml
+
+  test-metrics:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        test: [["per-hello-world", "ghcr.io/converged-computing/metric-sysstat:latest", 60]]
+
+    steps:
+    - name: Clone the code
+      uses: actions/checkout@v3
+
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ^1.18
+
+    - name: Install zeromq
+      run: sudo apt-get update && sudo apt-get install -y libsodium-dev libzmq3-dev libczmq-dev
+
+    - name: Start minikube
+      uses: medyagh/setup-minikube@697f2b7aaed5f70bf2a94ee21a4ec3dde7b12f92 # v0.0.9
+
+    - name: Pull Docker Containers to MiniKube
+      env:
+        container: ${{ matrix.test[1] }}
+        test: ${{ matrix[0] }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        export SHELL=/bin/bash
+        eval $(minikube -p minikube docker-env)
+        minikube ssh docker pull ${container}
+        make deploy-local
+        minikube image load ghcr.io/converged-computing/metrics-operator:test
+        kubectl apply -f examples/dist/metrics-operator-local.yaml
+
+    - name: Install JobSet
+      run: |
+        VERSION=v0.2.0
+        kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/download/$VERSION/manifests.yaml
+
+    - name: Test ${{ matrix.test[0] }}
+      env:
+        name: ${{ matrix.test[0] }}
+        jobtime: ${{ matrix.test[2] }}
+      run: /bin/bash ./script/test.sh ${name} ${jobtime}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -62,9 +62,6 @@ jobs:
       with:
         go-version: ^1.18
 
-    - name: Install zeromq
-      run: sudo apt-get update && sudo apt-get install -y libsodium-dev libzmq3-dev libczmq-dev
-
     - name: Start minikube
       uses: medyagh/setup-minikube@697f2b7aaed5f70bf2a94ee21a4ec3dde7b12f92 # v0.0.9
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -51,7 +51,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test: [["per-hello-world", "ghcr.io/converged-computing/metric-sysstat:latest", 60]]
+        test: [["perf-hello-world", "ghcr.io/converged-computing/metric-sysstat:latest", 60]]
 
     steps:
     - name: Clone the code

--- a/Makefile
+++ b/Makefile
@@ -311,9 +311,7 @@ $(HELMIFY): $(LOCALBIN)
 
 .PHONY: clean
 clean:
-	kubectl delete svc ms --grace-period=0 --force || true
-	kubectl delete cm metricset-sample --grace-period=0 --force
-	kubectl delete MetricSet --all --grace-period=0 --force
+	kubectl delete MetricSet --all --grace-period=0 --force || true
 
 helm: manifests kustomize helmify
 	$(KUSTOMIZE) build config/default | $(HELMIFY)

--- a/README.md
+++ b/README.md
@@ -10,9 +10,7 @@ View our ⭐️ [Documentation](https://converged-computing.github.io/metrics-op
 
 ## Dinosaur TODO
 
-- Add hello world example performance metric
-- Add tests as proper tests in CI
-- **Bug that config map not cleaning up with deletion**
+- osu-benchmark example
 - Need a strategy for storing metrics output / logs
 - For services we are measuring, we likely need to be able to kill after N seconds (to complete job) or to specify the success policy on the metrics containers instead of the application
 - TBA

--- a/controllers/metric/configmap.go
+++ b/controllers/metric/configmap.go
@@ -52,6 +52,13 @@ func (r *MetricSetReconciler) ensureConfigMaps(
 			data[key] = m.EntrypointScript(set)
 		}
 		cm, result, err := r.getConfigMap(ctx, set, data)
+		if err != nil {
+			r.Log.Error(
+				err, "❌ Failed to get config map",
+				"Namespace", cm.Namespace,
+				"Name", (*cm).Name,
+			)
+		}
 		return cm, result, err
 
 	} else {
@@ -61,7 +68,6 @@ func (r *MetricSetReconciler) ensureConfigMaps(
 			"Name", existing.Name,
 		)
 	}
-	ctrl.SetControllerReference(set, existing, r.Scheme)
 	return existing, ctrl.Result{}, err
 }
 
@@ -91,8 +97,8 @@ func (r *MetricSetReconciler) getConfigMap(
 	fmt.Println(cm.Data)
 
 	// Actually create it
-	err := r.Create(ctx, cm)
 	ctrl.SetControllerReference(set, cm, r.Scheme)
+	err := r.Create(ctx, cm)
 	if err != nil {
 		r.Log.Error(
 			err, "❌ Failed to create MetricSet ConfigMap",
@@ -101,7 +107,6 @@ func (r *MetricSetReconciler) getConfigMap(
 		)
 		return cm, ctrl.Result{}, err
 	}
-
 	// Successful - return and requeue
 	return cm, ctrl.Result{Requeue: true}, nil
 }

--- a/examples/tests/perf-hello-world/README.md
+++ b/examples/tests/perf-hello-world/README.md
@@ -1,0 +1,111 @@
+# Hello World Perf Example
+
+This is a simple "hello world" example for a performance metric, sysstat.
+
+## Usage
+
+Create a cluster and install JobSet to it.
+
+```bash
+kind create cluster
+VERSION=v0.2.0
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/jobset/releases/download/$VERSION/manifests.yaml
+```
+
+Install the operator (from the development manifest here):
+
+```bash
+$ kubectl apply -f ../../dist/metrics-operator-dev.yaml
+```
+
+How to see metrics operator logs:
+
+```bash
+$ kubectl logs -n metrics-system metrics-controller-manager-859c66464c-7rpbw 
+```
+
+Then create the metrics set. This is going to run a simple sysstat tool to collect metrics
+as lammps runs.
+
+```bash
+kubectl apply -f metrics.yaml
+```
+
+Wait until you see pods created by the job and then running (there should be one with two containers, one for the app lammps and the other for the stats):
+
+```bash
+kubectl get pods
+```
+```diff
+NAME                           READY   STATUS              RESTARTS   AGE
+- metricset-sample-m-0-0-mkwrh   0/2     ContainerCreating   0          2m20s
++ metricset-sample-m-0-0-mkwrh   2/2     Running             0          3m10s
+```
+
+You should always be able to get logs for the application container in a pod, which is named "app". Since this is a sleep, we won't see anything interesting. However, the sidecar metrics containers will output their metrics for the lifetime of the application, and (currently) also to their logs:
+
+```bash
+kubectl logs metricset-sample-m-0-czxrq -c perf-sysstat
+```
+```console
+05:39:24        0        20         -    0.00    0.00    0.00    0.00    0.00     4  mpirun
+05:39:24        0         -        20    0.00    0.00    0.00    0.00    0.00     4  |__mpirun
+KERNEL TABLES 2176
+        34  pidstat -p 20 -v -h
+    echo TASK SWITCHING 2176
+/metrics_operator/entrypoint-0.sh: line 28: 35: command not found
+CPU STATISTICS TIMEPOINT 2177
+    pidstat -p 20 -u -h
+    echo KERNEL STATISTICS TIMEPOINT 2177
+Linux 5.15.0-76-generic (metricset-sample-m-0-0)        07/29/23        _x86_64_    (8 CPU)
+
+# Time        UID       PID   kB_rd/s   kB_wr/s kB_ccwr/s iodelay  Command
+05:39:24        0        20      0.00      0.00      0.00       0  mpirun
+POLICY TIMEPOINT 2177
+    pidstat -p 20 -R -h
+    echo PAGEFAULTS and MEMORY 2177
+Linux 5.15.0-76-generic (metricset-sample-m-0-0)        07/29/23        _x86_64_    (8 CPU)
+
+# Time        UID       PID  minflt/s  majflt/s     VSZ     RSS   %MEM  Command
+05:39:24        0        20      0.00      0.00    6548    3160   0.02  mpirun
+STACK UTILIZATION 2177
+        pidstat -p 20 -s -h
+    echo THREADS 2177
+Linux 5.15.0-76-generic (metricset-sample-m-0-0)        07/29/23        _x86_64_    (8 CPU)
+
+# Time        UID      TGID       TID    %usr %system  %guest   %wait    %CPU   CPU  Command
+05:39:24        0        20         -    0.00    0.00    0.00    0.00    0.00     4  mpirun
+05:39:24        0         -        20    0.00    0.00    0.00    0.00    0.00     4  |__mpirun
+```
+
+Those are just a random set of stats I am running using this tool for the shared PID - I need to think
+of a better way to capture and save these! Also, right now we don't have a completion policy, but instead have
+the metrics collector exit when the PID goes away. In the future we could use a success policy. When you are done, the JobsSet, associated jobs, and pods will be completed:
+
+```bash
+$ kubectl get jobset
+```
+```console
+NAME               RESTARTS   COMPLETED   AGE
+metricset-sample              True        2m28s
+```
+```bash
+$ kubectl get jobs
+```
+```console
+NAME                   COMPLETIONS   DURATION   AGE
+metricset-sample-m-0   1/1           13s        2m51s
+```
+```bash
+$ kubectl get pods
+```
+```console
+NAME                           READY   STATUS      RESTARTS   AGE
+metricset-sample-m-0-0-rq4q9   0/2     Completed   0          3m19s
+```
+
+When you are done, cleanup!
+
+```bash
+kubectl delete -f metrics.yaml
+```

--- a/examples/tests/perf-hello-world/metrics.yaml
+++ b/examples/tests/perf-hello-world/metrics.yaml
@@ -1,0 +1,14 @@
+apiVersion: flux-framework.org/v1alpha1
+kind: MetricSet
+metadata:
+  labels:
+    app.kubernetes.io/name: metricset
+    app.kubernetes.io/instance: metricset-sample
+  name: metricset-sample
+spec:
+  # We don't have support currently for bash commands with -c quotes - hence the simple commands
+  application:
+    image: ubuntu
+    command: sleep 10
+  metrics:
+    - name: perf-sysstat

--- a/pkg/metrics/jobset.go
+++ b/pkg/metrics/jobset.go
@@ -136,6 +136,14 @@ func getReplicatedJob(
 func GetStorageJobSet(set *api.MetricSet, metrics *[]Metric) (*jobset.JobSet, error) {
 	js := getBaseJobSet(set, []string{replicatedJobName})
 
+	// TODO move this function + the getContainers into a common one -
+	// we should loop over each metric to make a jobset / containers
+	// Perhaps we can have a "set" level function that yields the replicatedJobs?
+	// If each metric can define its own jobset, and indexed by size, then
+	// we can create a replicated job named by the size, and then add
+	// containers to it.
+	// each replicated job still needs a completions / indexed mode.
+	// Perhaps we allow a metric to create one off replicated Jobs?
 	// We don't need a shared process namespace here
 	job := getReplicatedJob(set, false)
 

--- a/pkg/metrics/perf/sysstat.go
+++ b/pkg/metrics/perf/sysstat.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	api "github.com/converged-computing/metrics-operator/api/v1alpha1"
-
 	metrics "github.com/converged-computing/metrics-operator/pkg/metrics"
 )
 

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -1,0 +1,12 @@
+package utils
+
+import (
+	"strings"
+)
+
+// EscapeCharacters for a bash string
+func EscapeCharacters(str string) string {
+	str = strings.ReplaceAll(str, `"`, `\"`)
+	str = strings.ReplaceAll(str, "'", "\\'")
+	return str
+}

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Usage: /bin/bash script/test.sh $name 30
+HERE=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+ROOT=$(dirname ${HERE})
+cd ${ROOT}
+
+set -eEu -o pipefail
+
+name=${1}
+jobtime=${2:-30}
+
+echo "   Name: ${name}"
+echo "Jobtime: ${jobtime}"
+
+# Output and error files
+out="${ROOT}/examples/tests/${name}/${name}-log.out"
+err="${ROOT}/examples/tests/${name}/${name}-log.err"
+
+# Quick helper script to run a test
+make clean >> /dev/null 2>&1
+make run > ${out} 2> ${err} &
+pid=$!
+echo "PID for running cluster is ${pid}"
+
+kubectl apply -f examples/tests/${name}/metrics.yaml
+echo "Sleeping for ${jobtime} seconds to allow job to complete 😴️."
+sleep ${jobtime}
+
+# The job should be completed
+type=$(kubectl get jobset -o json | jq -r .items[0].status.conditions[0].type)
+echo "JobSet status type is ${type}"
+status=$(kubectl get jobset -o json | jq -r .items[0].status.conditions[0].status)
+
+if [[ "${status}" != "True" ]] || [[ "${type}" != "Completed" ]]; then
+    echo "Issue with running job ${name}"
+    exit 1
+fi
+
+kill ${pid} || true
+kill $(lsof -t -i:8080) || true


### PR DESCRIPTION
The config map was not properly owned by the MetricSet because the owner reference needed to be added before creation! And we are also adding a hello world sleep example intended to be run in a test.