### PR TITLE
refactor affinity to use same startegy as flux operator

### DIFF
--- a/docs/_static/data/metrics.json
+++ b/docs/_static/data/metrics.json
@@ -136,14 +136,6 @@
   "url": "https://gitlab.com/hpctoolkit/hpctoolkit"
  },
  {
-  "name": "perf-kit-benchmarker",
-  "description": "An open effort to define a canonical set of benchmarks to measure and compare cloud offerings.",
-  "family": "network",
-  "type": "standalone",
-  "image": "ghcr.io/converged-computing/metric-perf-kit-benchmarker:latest",
-  "url": "https://github.com/GoogleCloudPlatform/PerfKitBenchmarker"
- },
- {
   "name": "perf-sysstat",
   "description": "statistics for Linux tasks (processes) : I/O, CPU, memory, etc.",
   "family": "performance",

--- a/docs/_static/data/metrics.json
+++ b/docs/_static/data/metrics.json
@@ -136,6 +136,14 @@
   "url": "https://gitlab.com/hpctoolkit/hpctoolkit"
  },
  {
+  "name": "perf-kit-benchmarker",
+  "description": "An open effort to define a canonical set of benchmarks to measure and compare cloud offerings.",
+  "family": "network",
+  "type": "standalone",
+  "image": "ghcr.io/converged-computing/metric-perf-kit-benchmarker:latest",
+  "url": "https://github.com/GoogleCloudPlatform/PerfKitBenchmarker"
+ },
+ {
   "name": "perf-sysstat",
   "description": "statistics for Linux tasks (processes) : I/O, CPU, memory, etc.",
   "family": "performance",

--- a/pkg/jobs/launcher.go
+++ b/pkg/jobs/launcher.go
@@ -188,7 +188,7 @@ func (m *LauncherWorker) AddWorkers(
 ) (*jobset.ReplicatedJob, error) {
 
 	numWorkers := spec.Spec.Pods - 1
-	workers, err := metrics.GetReplicatedJob(spec, false, numWorkers, numWorkers, m.WorkerLetter)
+	workers, err := metrics.GetReplicatedJob(spec, false, numWorkers, numWorkers, m.WorkerLetter, m.SoleTenancy)
 	if err != nil {
 		return workers, err
 	}
@@ -221,7 +221,7 @@ func (m *LauncherWorker) ReplicatedJobs(spec *api.MetricSet) ([]jobset.Replicate
 	m.ensureDefaultNames()
 
 	// Generate a replicated job for the launcher (LauncherWorker) and workers
-	launcher, err := metrics.GetReplicatedJob(spec, false, 1, 1, m.LauncherLetter)
+	launcher, err := metrics.GetReplicatedJob(spec, false, 1, 1, m.LauncherLetter, m.SoleTenancy)
 	if err != nil {
 		return js, err
 	}

--- a/pkg/jobs/storage.go
+++ b/pkg/jobs/storage.go
@@ -47,6 +47,7 @@ func (m StorageGeneric) Description() string {
 	return m.Summary
 }
 
+// By default assume storage does not have sole tenancy
 func (m StorageGeneric) HasSoleTenancy() bool {
 	return false
 }

--- a/pkg/metrics/application.go
+++ b/pkg/metrics/application.go
@@ -56,7 +56,7 @@ func GetApplicationReplicatedJobs(
 	m := (*metric)
 
 	// This defaults to one replicated job, named "m", no custom replicated job name, and sole tenancy false
-	job, err := GetReplicatedJob(spec, shareProcessNamespace, spec.Spec.Pods, spec.Spec.Completions, "")
+	job, err := GetReplicatedJob(spec, shareProcessNamespace, spec.Spec.Pods, spec.Spec.Completions, "", m.HasSoleTenancy())
 	if err != nil {
 		return rjs, err
 	}

--- a/pkg/metrics/metricset.go
+++ b/pkg/metrics/metricset.go
@@ -48,7 +48,6 @@ type MetricSet interface {
 	Metrics() []*Metric
 	EntrypointScripts(*api.MetricSet) []EntrypointScript
 	ReplicatedJobs(*api.MetricSet) ([]jobset.ReplicatedJob, error)
-	HasSoleTenancy() bool
 }
 
 // get an application default entrypoint, if not determined by metric

--- a/pkg/metrics/storage.go
+++ b/pkg/metrics/storage.go
@@ -22,7 +22,7 @@ func (m *StorageMetricSet) ReplicatedJobs(spec *api.MetricSet) ([]jobset.Replica
 
 	// Storage metrics do not need to share the process namespace
 	// The jobname empty string will use the default, no custom replicated job name, and sole tenancy false
-	job, err := GetReplicatedJob(spec, false, spec.Spec.Pods, spec.Spec.Completions, "")
+	job, err := GetReplicatedJob(spec, false, spec.Spec.Pods, spec.Spec.Completions, "", m.HasSoleTenancy())
 	if err != nil {
 		return rjs, err
 	}


### PR DESCRIPTION
When we scaled the osu benchmarks up to 128, it seems like the current strategy for affinity didn't work - some  nodes were never given hostnames (and I'm not sure why). So I tried falling back to resources, but since we are asking for the smallest integer already (1) there is no way to ask for less than 1 cpu, so I resorted to memory. But doing this seems to use volume on the instance (I suspect it was using memory for this) so nothing works. So I'm trying a different strategy for affinity here - instead of applying the label that indicated needing it, I'm doing the same (more detailed) strategy as the flux operator has. Fingers crossed I guess!