### PR TITLE
Add/python parser generic

### DIFF
--- a/docs/_static/data/metrics.json
+++ b/docs/_static/data/metrics.json
@@ -144,4 +144,3 @@
   "url": "https://github.com/sysstat/sysstat"
  }
 ]
-

--- a/docs/_static/data/metrics.json
+++ b/docs/_static/data/metrics.json
@@ -144,3 +144,4 @@
   "url": "https://github.com/sysstat/sysstat"
  }
 ]
+

--- a/docs/_static/data/metrics.json
+++ b/docs/_static/data/metrics.json
@@ -136,14 +136,6 @@
   "url": "https://gitlab.com/hpctoolkit/hpctoolkit"
  },
  {
-  "name": "perf-kit-benchmarker",
-  "description": "An open effort to define a canonical set of benchmarks to measure and compare cloud offerings.",
-  "family": "network",
-  "type": "standalone",
-  "image": "ghcr.io/converged-computing/metric-perf-kit-benchmarker:latest",
-  "url": "https://github.com/GoogleCloudPlatform/PerfKitBenchmarker"
- },
- {
   "name": "perf-sysstat",
   "description": "statistics for Linux tasks (processes) : I/O, CPU, memory, etc.",
   "family": "performance",

--- a/docs/_static/data/metrics.json
+++ b/docs/_static/data/metrics.json
@@ -136,6 +136,14 @@
   "url": "https://gitlab.com/hpctoolkit/hpctoolkit"
  },
  {
+  "name": "perf-kit-benchmarker",
+  "description": "An open effort to define a canonical set of benchmarks to measure and compare cloud offerings.",
+  "family": "network",
+  "type": "standalone",
+  "image": "ghcr.io/converged-computing/metric-perf-kit-benchmarker:latest",
+  "url": "https://github.com/GoogleCloudPlatform/PerfKitBenchmarker"
+ },
+ {
   "name": "perf-sysstat",
   "description": "statistics for Linux tasks (processes) : I/O, CPU, memory, etc.",
   "family": "performance",

--- a/sdk/python/v1alpha1/CHANGELOG.md
+++ b/sdk/python/v1alpha1/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/metrics-operator/tree/main) (0.0.x)
+ - Allow getting raw logs for any metric (without parser) (0.0.19)
  - Refactor of structure of Operator and addition of metrics (0.0.18)
  - Add wait for delete function to python parser (0.0.17)
  - LAMMPS python parser (0.0.16)

--- a/sdk/python/v1alpha1/metricsoperator/client.py
+++ b/sdk/python/v1alpha1/metricsoperator/client.py
@@ -22,18 +22,20 @@ class MetricsOperator:
         self.spec = utils.read_yaml(self.yaml_file)
         config.load_kube_config()
 
-    def watch(self, raw_logs=False, pod_prefix=None):
+    def watch(self, raw_logs=False, pod_prefix=None, container_name=None):
         """
         Wait for (and yield parsed) metric logs.
         """
         if raw_logs and not pod_prefix:
-            raise ValueError('You must provide a pod_prefix to ask for raw logs.')
+            raise ValueError("You must provide a pod_prefix to ask for raw logs.")
 
         for metric in self.spec["spec"]["metrics"]:
             if raw_logs:
-                parser = mutils.get_metric()(self.spec)
-            else: 
-                parser = mutils.get_metric(metric["name"])(self.spec)
+                parser = mutils.get_metric()(self.spec, container_name=container_name)
+            else:
+                parser = mutils.get_metric(metric["name"])(
+                    self.spec, container_name=container_name
+                )
             print("Watching %s" % metric["name"])
             for pod, container in parser.logging_containers(pod_prefix=pod_prefix):
                 yield parser.parse(pod=pod, container=container)

--- a/sdk/python/v1alpha1/metricsoperator/metrics/__init__.py
+++ b/sdk/python/v1alpha1/metricsoperator/metrics/__init__.py
@@ -2,10 +2,10 @@
 # (c.f. AUTHORS, NOTICE.LLNS, COPYING)
 
 import metricsoperator.metrics.app as apps
+import metricsoperator.metrics.base as base
 import metricsoperator.metrics.network as network
 import metricsoperator.metrics.perf as perf
 import metricsoperator.metrics.storage as storage
-import metricsoperator.metrics.base as base
 
 metrics = {
     "io-sysstat": storage.io_sysstat,

--- a/sdk/python/v1alpha1/metricsoperator/metrics/__init__.py
+++ b/sdk/python/v1alpha1/metricsoperator/metrics/__init__.py
@@ -5,6 +5,7 @@ import metricsoperator.metrics.app as apps
 import metricsoperator.metrics.network as network
 import metricsoperator.metrics.perf as perf
 import metricsoperator.metrics.storage as storage
+import metricsoperator.metrics.base as base
 
 metrics = {
     "io-sysstat": storage.io_sysstat,
@@ -17,11 +18,12 @@ metrics = {
 }
 
 
-def get_metric(name):
+def get_metric(name=None):
     """
     Get a named metric parser.
     """
     metric = metrics.get(name)
+    # If we don't have a matching metric, return base (for raw logs)
     if not metric:
-        raise ValueError(f"Metric {name} does not have a known parser")
+        return base.MetricBase
     return metric

--- a/sdk/python/v1alpha1/metricsoperator/metrics/base.py
+++ b/sdk/python/v1alpha1/metricsoperator/metrics/base.py
@@ -66,7 +66,7 @@ class MetricBase:
         """
         # Get the log metadata, split lines by newline so not so hefty a log!
         metadata = self.get_log_metadata(lines)
-        return {"data": lines.split(), "metadata": metadata, "spec": self.spec}
+        return {"data": lines.split("\n"), "metadata": metadata, "spec": self.spec}
 
     @property
     def core_v1(self):

--- a/sdk/python/v1alpha1/metricsoperator/metrics/base.py
+++ b/sdk/python/v1alpha1/metricsoperator/metrics/base.py
@@ -64,9 +64,9 @@ class MetricBase:
         """
         If the parser doesn't have anything, just return the lines
         """
-        # Get the log metadata
+        # Get the log metadata, split lines by newline so not so hefty a log!
         metadata = self.get_log_metadata(lines)
-        return {"data": lines, "metadata": metadata, "spec": self.spec}
+        return {"data": lines.split(), "metadata": metadata, "spec": self.spec}
 
     @property
     def core_v1(self):

--- a/sdk/python/v1alpha1/setup.py
+++ b/sdk/python/v1alpha1/setup.py
@@ -30,7 +30,7 @@ except Exception:
 if __name__ == "__main__":
     setup(
         name="metricsoperator",
-        version="0.0.18",
+        version="0.0.19",
         author="Vanessasaurus",
         author_email="vsoch@users.noreply.github.com",
         maintainer="Vanessasaurus",


### PR DESCRIPTION
This will add a more generic parser that presents complete raw logs (without parsing). I'm adding this because for official experiments I would rather be conservative and collect the entire log vs. risk a parsing bug and miss something.