### PR TITLE
fixing bug with systat interactive move

### DIFF
--- a/pkg/metrics/perf/sysstat.go
+++ b/pkg/metrics/perf/sysstat.go
@@ -236,12 +236,12 @@ while true
 	retval=$?
 	if [[ $retval -ne 0 ]]; then
 		echo "%s"
-        %s
+		%s
 		exit 0
 	fi
 	if [[ $completions -ne 0 ]] && [[ $i -eq $completions ]]; then
 		echo "%s"
-        %s
+		%s
 		exit 0
 	fi
 	sleep %d

--- a/pkg/metrics/perf/sysstat.go
+++ b/pkg/metrics/perf/sysstat.go
@@ -236,10 +236,12 @@ while true
 	retval=$?
 	if [[ $retval -ne 0 ]]; then
 		echo "%s"
+        %s
 		exit 0
 	fi
 	if [[ $completions -ne 0 ]] && [[ $i -eq $completions ]]; then
 		echo "%s"
+        %s
 		exit 0
 	fi
 	sleep %d
@@ -259,7 +261,9 @@ done
 		metadata.Separator,
 		showPIDS,
 		metadata.CollectionEnd,
+		interactive,
 		metadata.CollectionEnd,
+		interactive,
 		m.rate,
 	)
 	postBlock := fmt.Sprintf("\n%s\n", interactive)


### PR DESCRIPTION
And there is an underlying bug with the pidstat command parsing with jc. We will want to update the command to use -T ALL when it is fixed - I will update the PR here.