### PR TITLE
fix: allow metrics operator python sdk to take custom kubeconfig

### DIFF
--- a/sdk/python/v1alpha2/CHANGELOG.md
+++ b/sdk/python/v1alpha2/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/metrics-operator/tree/main) (0.0.x)
+ - Support to provide custom kubeconfig (0.1.11)
  - LAMMPS parsing should include row names for component names (0.1.1)
  - More specific parsing / control for OSU benchmarks (0.0.21)
  - Support for OSU benchmark parsing with timed wrappers (0.0.2)

--- a/sdk/python/v1alpha2/metricsoperator/utils.py
+++ b/sdk/python/v1alpha2/metricsoperator/utils.py
@@ -6,6 +6,17 @@ import os
 import re
 
 import yaml
+from kubernetes import client, config
+
+
+def make_k8s_client(kubeconfig_yaml):
+    """
+    Load the yaml config for use in Python
+    """
+    with open(kubeconfig_yaml) as f:
+        kubeconfig = yaml.safe_load(f)
+    api_client = config.new_client_from_config_dict(kubeconfig)
+    return client.CoreV1Api(api_client)
 
 
 def read_file(filename):

--- a/sdk/python/v1alpha2/setup.py
+++ b/sdk/python/v1alpha2/setup.py
@@ -30,7 +30,7 @@ except Exception:
 if __name__ == "__main__":
     setup(
         name="metricsoperator",
-        version="0.1.1",
+        version="0.1.11",
         author="Vanessasaurus",
         author_email="vsoch@users.noreply.github.com",
         maintainer="Vanessasaurus",


### PR DESCRIPTION
Problem: right now we get some separation of logic if we use the metricsoperator python sdk to run the lammps metric - we may mix up control between a local kubeconfig and the one on aws, which is bad.
Solution: allow the user to provide the path to the kubeconfig.yaml (which kubescaler produces) that is carried forward to all metrics controllers to avoid this!