### PR TITLE
add support for init container

### DIFF
--- a/docs/getting_started/metrics.md
+++ b/docs/getting_started/metrics.md
@@ -25,7 +25,8 @@ There is a [nice tutorial here](https://www.open-mpi.org/projects/hwloc/tutorial
 |-----|-------------|------------|------|
 | command | Change the default command to something else. | string | lstopo architecture.png && hwloc-ls machine.xml |
 
-The above saves a png image, and the machine data to xml.
+The above saves a png image, and the machine data to xml. Note that if you need to copy the data post-run, you
+likely want to set `interactive: true` to keep it running.
 
 
 ### perf-sysstat

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -46,6 +46,7 @@ type Addon interface {
 	// What addons can control:
 	AssembleVolumes() []specs.VolumeSpec
 	AssembleContainers() []specs.ContainerSpec
+
 	CustomizeEntrypoints([]*specs.ContainerSpec, []*jobset.ReplicatedJob)
 
 	// Instead of exposing individual pieces (volumes, settings, etc)

--- a/pkg/addons/containers.go
+++ b/pkg/addons/containers.go
@@ -62,10 +62,6 @@ func (a *ApplicationAddon) Validate() bool {
 	return true
 }
 
-func (a ApplicationAddon) AssembleInitContainers() []specs.ContainerSpec {
-	return []specs.ContainerSpec{}
-}
-
 // AssembleContainers adds the addon application container
 func (a ApplicationAddon) AssembleContainers() []specs.ContainerSpec {
 	return []specs.ContainerSpec{{

--- a/pkg/addons/containers.go
+++ b/pkg/addons/containers.go
@@ -62,6 +62,10 @@ func (a *ApplicationAddon) Validate() bool {
 	return true
 }
 
+func (a ApplicationAddon) AssembleInitContainers() []specs.ContainerSpec {
+	return []specs.ContainerSpec{}
+}
+
 // AssembleContainers adds the addon application container
 func (a ApplicationAddon) AssembleContainers() []specs.ContainerSpec {
 	return []specs.ContainerSpec{{

--- a/pkg/addons/mpitrace.go
+++ b/pkg/addons/mpitrace.go
@@ -57,6 +57,7 @@ func (a *MPITrace) SetOptions(metric *api.MetricAddon, m *api.MetricSet) {
 	a.VolumeName = "mpitrace"
 	a.Identifier = mpitraceIdentifier
 	a.SpackViewContainer = "mpitrace"
+	a.InitContainer = true
 
 	mount, ok := metric.Options["mount"]
 	if ok {

--- a/pkg/metrics/base.go
+++ b/pkg/metrics/base.go
@@ -159,6 +159,8 @@ func (m BaseMetric) AddAddons(
 
 		// Assemble containers that addons provide, also as specs
 		assembleContainers := a.AssembleContainers()
+
+		// Sidecar containers
 		for _, assembleContainer := range assembleContainers {
 
 			// Any container specs that need to be created later as config maps are kept in cms
@@ -186,11 +188,12 @@ func (m BaseMetric) AddAddons(
 	for _, rj := range rjs {
 
 		// We also include the addon volumes, which generally need mount points
-		rjContainers, err := getReplicatedJobContainers(spec, rj, containers, volumes)
+		rjContainers, initContainers, err := getReplicatedJobContainers(spec, rj, containers, volumes)
 		if err != nil {
 			return cms, err
 		}
 		rj.Template.Spec.Template.Spec.Containers = rjContainers
+		rj.Template.Spec.Template.Spec.InitContainers = initContainers
 
 		// And volumes!
 		// containerSpecs are used to generate our metric entrypoint volumes

--- a/pkg/specs/specs.go
+++ b/pkg/specs/specs.go
@@ -26,6 +26,7 @@ type ContainerSpec struct {
 	Image            string
 	Name             string
 	WorkingDir       string
+	InitContainer    bool
 	EntrypointScript EntrypointScript
 
 	// If a command is provided, it's likely an addon (and EntrypointScript is ignored)

--- a/sdk/python/v1alpha2/CHANGELOG.md
+++ b/sdk/python/v1alpha2/CHANGELOG.md
@@ -14,6 +14,7 @@ and **Merged pull requests**. Critical items to know are:
 The versions coincide with releases on pip. Only major versions will be released as tags on Github.
 
 ## [0.0.x](https://github.com/converged-computing/metrics-operator/tree/main) (0.0.x)
+ - initContainer support for mpitrace and function to get parser (0.1.12)
  - Support to provide custom kubeconfig (0.1.11)
  - LAMMPS parsing should include row names for component names (0.1.1)
  - More specific parsing / control for OSU benchmarks (0.0.21)

--- a/sdk/python/v1alpha2/setup.py
+++ b/sdk/python/v1alpha2/setup.py
@@ -30,7 +30,7 @@ except Exception:
 if __name__ == "__main__":
     setup(
         name="metricsoperator",
-        version="0.1.11",
+        version="0.1.12",
         author="Vanessasaurus",
         author_email="vsoch@users.noreply.github.com",
         maintainer="Vanessasaurus",


### PR DESCRIPTION
for many metrics, we want them to clean up on their own (e.g., have the job complete). Right now, one container stays running and the state goes to NotReady. Given we use ORAS to push to an OCI cache, we do not need to keep them running to copy anything over. If a user wants to keep the metric running, they can just use interactive:true instead